### PR TITLE
Switching file loading from system loader to thread context class loader.

### DIFF
--- a/src/main/java/org/powertac/householdcustomer/HouseholdCustomerService.java
+++ b/src/main/java/org/powertac/householdcustomer/HouseholdCustomerService.java
@@ -160,7 +160,7 @@ implements NewTariffListener, InitializationService
 
     InputStream cfgFile = null;
     // cfgFile = new FileInputStream(configFile);
-    cfgFile = ClassLoader.getSystemResourceAsStream(configFile1);
+    cfgFile = Thread.currentThread().getContextClassLoader().getResourceAsStream(configFile1);
     try {
       configuration.load(cfgFile);
       cfgFile.close();
@@ -190,7 +190,7 @@ implements NewTariffListener, InitializationService
 
     cfgFile = null;
     // cfgFile = new FileInputStream(configFile);
-    cfgFile = ClassLoader.getSystemResourceAsStream(configFile2);
+    cfgFile = Thread.currentThread().getContextClassLoader().getResourceAsStream(configFile2);
     try {
       configuration.load(cfgFile);
       cfgFile.close();
@@ -220,7 +220,7 @@ implements NewTariffListener, InitializationService
 
     cfgFile = null;
     // cfgFile = new FileInputStream(configFile);
-    cfgFile = ClassLoader.getSystemResourceAsStream(configFile3);
+    cfgFile = Thread.currentThread().getContextClassLoader().getResourceAsStream(configFile3);
     try {
       configuration.load(cfgFile);
       cfgFile.close();
@@ -250,7 +250,7 @@ implements NewTariffListener, InitializationService
 
     cfgFile = null;
     // cfgFile = new FileInputStream(configFile);
-    cfgFile = ClassLoader.getSystemResourceAsStream(configFile4);
+    cfgFile = Thread.currentThread().getContextClassLoader().getResourceAsStream(configFile4);
     try {
       configuration.load(cfgFile);
       cfgFile.close();


### PR DESCRIPTION
Following message applies to household customer as well as factored customer plugin.

It appears that system class loader in Tomcat/Jetty is not working the way it works in desktop enviroment. 

Tomcat in its classpath have only two files, none of them are config files for powertac plugins: bootstrap.jar and tools.jar.

Forcing tomcat/jetty to put config files into system class loader is not an easy task and probably not the best idea.

Proposed solution is to switch from retrieving config files using system class loader to using thread context class loader, as you can see in the source code modification.

I have sucessfully tested this solution with an Eclipse integrated version of Tomcat, a maven deployment of Jetty server, and standard competition run using maven call from bash (server-distribution). 

If there is some other and better solution for this issue, please help.

Thanks,
Jurica
